### PR TITLE
update error to use correct ack

### DIFF
--- a/server/session.rb
+++ b/server/session.rb
@@ -196,7 +196,7 @@ class Session
 
     # Validate the acknowledgement number
     if(!valid_ack?(packet.body.ack))
-      notify_subscribers(:dnscat2_session_error, [@id, "Bad acknowledgement number: expected 0x%04x, received 0x%04x" % [@my_seq, packet.ack]])
+      notify_subscribers(:dnscat2_session_error, [@id, "Bad acknowledgement number: expected 0x%04x, received 0x%04x" % [@my_seq, packet.body.ack]])
 
       # Re-send the last packet
       old_data = next_outgoing(actual_msg_max_length(max_length))


### PR DESCRIPTION
Received error
```
[ERROR] Error caught:
[ERROR] [NoMethodError]: undefined method `ack' for #<Packet:0x007fe5e1cedcf8>
```

Solved by replacing packet.ack => packet.body.ack