### PR TITLE
Adding case-insensitive regex

### DIFF
--- a/server/driver_dns.rb
+++ b/server/driver_dns.rb
@@ -129,14 +129,14 @@ class DriverDNS
   def DriverDNS.figure_out_name(name, domains)
     # Check if it's one of our domains
     domains.each do |domain|
-      if(name =~ /^(.*)\.(#{domain})/)
+      if(name =~ /^(.*)\.(#{domain})/i)
         return $1, $2
       end
     end
 
     # Check if it starts with dnscat, which is used when
     # the server is unknown
-    if(name =~ /^dnscat\.(.*)$/)
+    if(name =~ /^dnscat\.(.*)$/i)
       return $1, nil
     end
 
@@ -168,7 +168,7 @@ class DriverDNS
       domain_regex = "(^dnscat\\.|" + (domains.map { |x| "\\.#{x}$" }).join("|") + ")"
 
       # Only match proper domains with proper record types
-      match(/#{domain_regex}/, RECORD_TYPES.keys) do |transaction|
+      match(/#{domain_regex}/i, RECORD_TYPES.keys) do |transaction|
         begin
           # Determine the type
           type = transaction.resource_class


### PR DESCRIPTION
During a test I had an issue with an DNS resolver of my target host malforming the DNS queries (uppercase/lowercase). Beause of this, the dnscat2 server was unable to establish a session. I fixed this issue by adding case-insensitive regex modifiers (/i).