### PR TITLE
OS X Fast-Fix

### DIFF
--- a/client/libs/tcp.c
+++ b/client/libs/tcp.c
@@ -22,6 +22,10 @@
 
 #include "tcp.h"
 
+#ifndef INADDR_NONE
+#define INADDR_NONE ((in_addr_t) -1)
+#endif
+ 
 void winsock_initialize()
 {
 #ifdef WIN32

--- a/client/libs/udp.c
+++ b/client/libs/udp.c
@@ -22,6 +22,10 @@
 
 #include "udp.h"
 
+#ifndef INADDR_NONE
+#define INADDR_NONE ((in_addr_t) -1)
+#endif
+ 
 int udp_create_socket(uint16_t port, char *local_address)
 {
   int    s;


### PR DESCRIPTION
Fixing error: use of undeclared identifier 'INADDR_NONE'