### PR TITLE
Update byte_order.h - Support compilation on OSX

### DIFF
--- a/client/libs/crypto/byte_order.h
+++ b/client/libs/crypto/byte_order.h
@@ -129,8 +129,11 @@ static inline uint64_t bswap_64(uint64_t x) {
 }
 #elif defined(__FreeBSD__)
 # define bswap_64(x) bswap64(x)
+#elif defined(__APPLE__)
+# include <libkern/OSByteOrder.h>
+# define bswap_64 OSSwapInt64
 #else
-#error "bswap_64 unsupported"
+# error "bswap_64 unsupported"
 #endif
 
 #ifdef CPU_BIG_ENDIAN


### PR DESCRIPTION
I've used this for reference: 
https://github.com/aggregateknowledge/postgresql-hll/issues/6