### PR TITLE
Hack to fix RCODE_NAME_ERROR during shell

### DIFF
--- a/server/drivers/driver_console.rb
+++ b/server/drivers/driver_console.rb
@@ -8,6 +8,8 @@
 ##
 
 class DriverConsole
+  attr_reader :stopped
+  
   def initialize(window, settings)
     @window = window
     @settings = settings


### PR DESCRIPTION
I have no idea what I'm doing, but this fixes the RCODE_NAME_ERROR on the client when initializing a shell from the server.
Error server side:

#<NoMethodError: undefined method `stopped' for #<DriverConsole:0x00000000d78020>>
/home/ubuntu/dnscat2/server/controller/session.rb:396:in `block in feed'
/home/ubuntu/dnscat2/server/controller/encryptor.rb:244:in `decrypt_and_encrypt'
/home/ubuntu/dnscat2/server/controller/session.rb:394:in `feed'
/home/ubuntu/dnscat2/server/controller/controller.rb:91:in `feed'
/home/ubuntu/dnscat2/server/tunnel_drivers/tunnel_drivers.rb:25:in `block in start'
/home/ubuntu/dnscat2/server/tunnel_drivers/driver_dns.rb:316:in `call'
/home/ubuntu/dnscat2/server/tunnel_drivers/driver_dns.rb:316:in `block in initialize'
/home/ubuntu/dnscat2/server/libs/dnser.rb:872:in `call'
/home/ubuntu/dnscat2/server/libs/dnser.rb:872:in `block (2 levels) in on_request'
/home/ubuntu/dnscat2/server/libs/dnser.rb:843:in `loop'
/home/ubuntu/dnscat2/server/libs/dnser.rb:843:in `block in on_request'

So session expects the stopped method/attribute to be available, but not all drivers will have it. Or at least that is my interpretation of the bug.

Shell commands still seem to fail with this patch. So I will keep on debugging.