### PR TITLE
getopt_long_only() returns an int

### DIFF
--- a/client/dnscat.c
+++ b/client/dnscat.c
@@ -398,7 +398,7 @@ int main(int argc, char *argv[])
     {0,              0,                 0, 0}  /* End */
   };
 
-  char              c;
+  int               c;
   int               option_index;
   const char       *option_name;
 
@@ -422,7 +422,7 @@ int main(int argc, char *argv[])
 
   /* Parse the command line options. */
   opterr = 0;
-  while((c = getopt_long_only(argc, argv, "", long_options, &option_index)) != EOF)
+  while((c = getopt_long_only(argc, argv, "", long_options, &option_index)) != -1)
   {
     switch(c)
     {


### PR DESCRIPTION
Fixes a bug that reveals itself on certain platforms where `char` is unsigned by default. When -1 is returned by getopt_long_only() it is interpreted as unsigned, i.e. 255. This leads dnscat to always complain that an unrecognised argument has been passed.

I found this whilst cross-compiling for RPi. See http://stackoverflow.com/questions/17070958/c-why-does-getopt-return-255-on-linux for similar discussion.