### PR TITLE
Caching is controlled via a command line option

### DIFF
--- a/server/controller/controller_commands.rb
+++ b/server/controller/controller_commands.rb
@@ -196,7 +196,7 @@ module ControllerCommands
         TunnelDrivers.start({
           :controller => self,
           :driver     => DriverDNS,
-          :args       => [dns[:host], dns[:port], dns[:domains]]
+          :args       => [dns[:host], dns[:port], dns[:domains], opts[:cache]]
         })
       end
     )

--- a/server/dnscat2.rb
+++ b/server/dnscat2.rb
@@ -88,6 +88,9 @@ opts = Trollop::options do
 
   opt :firehose,       "If set, all output goes to stdout instead of being put in windows.",
     :type => :boolean, :default => false
+
+  opt :cache,       "If set, caching is enabled on the server.",
+    :type => :boolean, :default => true
 end
 
 SWindow.set_firehose(opts[:firehose])
@@ -205,7 +208,7 @@ dns_settings[:domains] += ARGV
 TunnelDrivers.start({
   :controller => controller,
   :driver     => DriverDNS,
-  :args       => [dns_settings[:host], dns_settings[:port], dns_settings[:domains]],
+  :args       => [dns_settings[:host], dns_settings[:port], dns_settings[:domains], opts[:cache]],
 })
 
 # Wait for the input window to finish its thing

--- a/server/tunnel_drivers/driver_dns.rb
+++ b/server/tunnel_drivers/driver_dns.rb
@@ -242,13 +242,13 @@ class DriverDNS
     return response
   end
 
-  def initialize(parent_window, host, port, domains)
+  def initialize(parent_window, host, port, domains, cache)
     if(domains.nil?)
       domains = []
     end
 
     # Do this as early as we can, so we can fail early
-    @dnser = DNSer.new(host, port, true)
+    @dnser = DNSer.new(host, port, cache)
 
     @id = 'dns%d' % (@@id += 1)
     @window = SWindow.new(parent_window, false, {


### PR DESCRIPTION
This change allows the user to enable/disable caching on the server from the command line.