### PR TITLE
Solaris10 further work

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ On Windows, load client/win32/dnscat2.vcproj into Visual Studio and hit
 free legit copy of a newer version, I'll likely be sticking with that
 one. :)
 
+**NB: You need a recent gcc compiler**. On Solaris 10, the gcc that ships with 
+it-  3.4.3 produces buggy code in encryption routines and you will expericence crashes.
+Try with [CSW gcc 5.5.0](https://www.opencsw.org/packages/CSWgcc5core/)
+
 If compilation fails, please file a bug on my [github
 page](https://github.com/iagox86/dnscat2/issues)! Please send details
 about your system.

--- a/client/Makefile
+++ b/client/Makefile
@@ -7,9 +7,9 @@
 # Should work for Linux and BSD make.
 
 CC?=gcc
-DEBUG_CFLAGS?=-DTESTMEMORY -Werror -O0
+DEBUG_CFLAGS?=-DTESTMEMORY -Werror -O0 -g -ggdb
 RELEASE_CFLAGS?=-Os
-CFLAGS?=--std=c89 -I. -Wall -D_DEFAULT_SOURCE  -Wformat -Wformat-security -g
+CFLAGS?=--std=c89 -I. -Wall -D_DEFAULT_SOURCE  -Wformat -Wformat-security 
 LIBS=-pie -Wl,-z,relro,-z,now 
 LDFLAGS=
 

--- a/client/dnscat.c
+++ b/client/dnscat.c
@@ -392,8 +392,8 @@ int main(int argc, char *argv[])
 #endif
 
     /* Debug options */
-    {"d",            no_argument, 0, 0}, /* More debug */
-    {"q",            no_argument, 0, 0}, /* Less debug */
+    {"debug",            no_argument, 0, 0}, /* More debug */
+    {"quiet",            no_argument, 0, 0}, /* Less debug */
     {"packet-trace", no_argument, 0, 0}, /* Trace packets */
 
     /* Sentry */
@@ -527,7 +527,7 @@ int main(int argc, char *argv[])
         }
 
         /* Debug options */
-        else if(!strcmp(option_name, "d"))
+        else if(!strcmp(option_name, "debug"))
         {
           if(min_log_level > 0)
           {
@@ -535,7 +535,7 @@ int main(int argc, char *argv[])
             log_set_min_console_level(min_log_level);
           }
         }
-        else if(!strcmp(option_name, "q"))
+        else if(!strcmp(option_name, "quiet"))
         {
           min_log_level++;
           log_set_min_console_level(min_log_level);

--- a/client/dnscat.c
+++ b/client/dnscat.c
@@ -287,7 +287,7 @@ driver_dns_t *create_dns_driver_internal(select_group_t *group, char *domain, ch
   }
 
   printf("Creating DNS driver:\n");
-  printf(" domain = %s\n", domain);
+  printf(" domain = %s\n", (domain ? domain :""));
   printf(" host   = %s\n", host);
   printf(" port   = %u\n", port);
   printf(" type   = %s\n", type);

--- a/client/libs/crypto/micro-ecc/uECC.c
+++ b/client/libs/crypto/micro-ecc/uECC.c
@@ -1,4 +1,5 @@
 /* Copyright 2014, Kenneth MacKay. Licensed under the BSD 2-clause license. */
+#pragma GCC diagnostic ignored "-Wchar-subscripts"
 
 #include "uECC.h"
 #include "uECC_vli.h"


### PR DESCRIPTION

* This PR fixes a NULL pointer deref and crash issue when domain is empty (no --dns or domain).
* It also changes -d to --debug (and -q to --quiet) as try as I might the getopt_long_only routine that is used to parse it would fail on Sol10. 
* Squelch of warnings in uECC.c file to allow a debug build  compile.
