### PR TITLE
Handle error conditions better

### DIFF
--- a/server/libs/dnser.rb
+++ b/server/libs/dnser.rb
@@ -675,7 +675,9 @@ class DNSer
                 ].pack("nnnnnn")
 
       questions.each do |q|
-        result += q.serialize()
+        unless  q.nil? then
+          result += q.serialize()
+        end
       end
 
       answers.each do |a|
@@ -841,6 +843,8 @@ class DNSer
     @thread = Thread.new() do |t|
       begin
         loop do
+          goterror=false
+	  begin
           data = @s.recvfrom(65536)
 
           # Data is an array where the first element is the actual data, and the second is the host/port
@@ -866,8 +870,13 @@ class DNSer
               end
             end
           end
+          rescue Exception => e
+            puts("Caught an error: #{e}")
+            puts(e.backtrace())
+            goterror=true
+          end
 
-          if(!transaction.sent)
+          if(!goterror and !transaction.sent)
             begin
               proc.call(transaction)
             rescue StandardError => e


### PR DESCRIPTION
Display stack trace, but do not fail and exit
(losing shells can be nightmare)

For example, dnscat2 server fails with following error messages on long running servers:

Caught an error: DNS packet was truncated (or we messed up parsing it)!
/pentest/dnscat2/server/libs/dnser.rb:179:in `unpack'
/pentest/dnscat2/server/libs/dnser.rb:634:in `parse'
/pentest/dnscat2/server/libs/dnser.rb:849:in `block (2 levels) in on_request'
/pentest/dnscat2/server/libs/dnser.rb:843:in `loop'
/pentest/dnscat2/server/libs/dnser.rb:843:in `block in on_request'

Protocol exception caught in dnscat DNS module (for more information, check window 'dns1'):
#<DnscatException: Received a packet with no questions>
Caught an error: undefined method `serialize' for nil:NilClass
/pentest/dnscat2/server/libs/dnser.rb:678:in `block in serialize'
/pentest/dnscat2/server/libs/dnser.rb:677:in `each'
/pentest/dnscat2/server/libs/dnser.rb:677:in `serialize'
/pentest/dnscat2/server/libs/dnser.rb:819:in `reply!'
/pentest/dnscat2/server/libs/dnser.rb:775:in `error!'
/pentest/dnscat2/server/tunnel_drivers/driver_dns.rb:357:in `rescue in block in initialize'
/pentest/dnscat2/server/tunnel_drivers/driver_dns.rb:293:in `block in initialize'
/pentest/dnscat2/server/libs/dnser.rb:879:in `block (2 levels) in on_request'
/pentest/dnscat2/server/libs/dnser.rb:843:in `loop'
/pentest/dnscat2/server/libs/dnser.rb:843:in `block in on_request'
/pentest/dnscat2/server/libs/dnser.rb:883:in `rescue in block (2 levels) in on_request': undefined method `response_template' for #<DNSer::Transaction:0x0000000000dd6a58> (NoMethodError)
Did you mean?  respond_to?
        from /pentest/dnscat2/server/libs/dnser.rb:878:in `block (2 levels) in on_request'
        from /pentest/dnscat2/server/libs/dnser.rb:843:in `loop'
        from /pentest/dnscat2/server/libs/dnser.rb:843:in `block in on_request'