### PR TITLE
Fix cache-hit induced server crash

### DIFF
--- a/server/libs/dnser.rb
+++ b/server/libs/dnser.rb
@@ -804,7 +804,7 @@ class DNSer
       @sent = true
     end
 
-    def reply!()
+    def reply!(_="")
       raise ArgumentError("Already sent!") if(@sent)
 
       # Cache it if we have a cache


### PR DESCRIPTION
Whenever there's a cache hit the server crashes with an "incorrect number of arguments" exception for _reply!_, this [mildly-mediocre] fix corrects all the instances which pass an argument to _reply!_ by just dropping it, the default value ensures it doesn't break anywhere else.