### PR TITLE
Adds shutdown method to DriverConsole

### DIFF
--- a/server/drivers/driver_console.rb
+++ b/server/drivers/driver_console.rb
@@ -39,4 +39,7 @@ class DriverConsole
 
     return out
   end
+
+  def shutdown()
+  end
 end


### PR DESCRIPTION
This gets rid errors when you exit a console window (e.g. if you open a new window with exec -c /bin/bash and then switch to it and type exit)  
```
Error caught (for more information, check window 'dns1'):
#<NoMethodError: undefined method `shutdown' for #<DriverConsole:0x00005605f542ebd0>>
```