### PR TITLE
Traps SIGINT so that an accidental Ctrl-C does not kill the whole server

### DIFF
--- a/server/dnscat2.rb
+++ b/server/dnscat2.rb
@@ -10,7 +10,9 @@
 ##
 
 $LOAD_PATH << File.dirname(__FILE__) # A hack to make this work on 1.8/1.9
-
+trap "SIGINT" do
+  puts "Ctrl-C is disabled, use exit"
+end
 # Create the window right away so other includes can create their own windows if they want
 require 'libs/swindow'
 WINDOW = SWindow.new(nil, true, { :prompt => "dnscat2> ", :name => "main" })


### PR DESCRIPTION
This makes it so that dnscat2 server does not exit on Ctrl-C. This accidentally happened to me too many times...