### PR TITLE
Bignum,Fixnum => Integer

### DIFF
--- a/server/controller/crypto_helper.rb
+++ b/server/controller/crypto_helper.rb
@@ -10,16 +10,16 @@
 
 class CryptoHelper
   def CryptoHelper.bignum_to_binary(bn, size=32)
-    if(!bn.is_a?(Bignum))
-      raise(ArgumentError, "Expected: Bignum; received: #{bn.class}")
+    if(!bn.is_a?(Integer))
+      raise(ArgumentError, "Expected: Integer; received: #{bn.class}")
     end
 
     return [bn.to_s(16).rjust(size*2, "\0")].pack("H*")
   end
 
   def CryptoHelper.bignum_to_text(bn, size=32)
-    if(!bn.is_a?(Bignum))
-      raise(ArgumentError, "Expected: Bignum; received: #{bn.class}")
+    if(!bn.is_a?(Integer))
+      raise(ArgumentError, "Expected: Integer; received: #{bn.class}")
     end
 
     return CryptoHelper.bignum_to_binary(bn, size).unpack("H*").pop()

--- a/server/controller/packet.rb
+++ b/server/controller/packet.rb
@@ -225,8 +225,8 @@ class Packet
         @public_key_x = params[:public_key_x] || raise(DnscatException, "params[:public_key_x] is required!")
         @public_key_y = params[:public_key_y] || raise(DnscatException, "params[:public_key_y] is required!")
 
-        if(!@public_key_x.is_a?(Bignum) || !@public_key_y.is_a?(Bignum))
-          raise(DnscatException, "Public keys have to be Bignums! (Seen: #{@public_key_x.class} #{@public_key_y.class})")
+        if(!@public_key_x.is_a?(Integer) || !@public_key_y.is_a?(Integer))
+          raise(DnscatException, "Public keys have to be Integers! (Seen: #{@public_key_x.class} #{@public_key_y.class})")
         end
       elsif(@subtype == SUBTYPE_AUTH)
         @authenticator = params[:authenticator] || raise(DnscatException, "params[:authenticator] is required!")

--- a/server/libs/dnser.rb
+++ b/server/libs/dnser.rb
@@ -376,7 +376,7 @@ class DNSer
       attr_accessor :preference, :name
 
       def initialize(name, preference = 10)
-        if(!name.is_a?(String) || !preference.is_a?(Fixnum))
+        if(!name.is_a?(String) || !preference.is_a?(Integer))
           raise ArgumentError("Creating an MX record wrong! Please file a bug!")
         end
         @name = name


### PR DESCRIPTION
This gets rid of deprecation warnings:
```
/home/ngo/dnscat2/server/controller/packet.rb:228: warning: constant ::Bignum is deprecated
/home/ngo/dnscat2/server/controller/packet.rb:228: warning: constant ::Bignum is deprecated
/home/ngo/dnscat2/server/controller/crypto_helper.rb:13: warning: constant ::Bignum is deprecated
/home/ngo/dnscat2/server/controller/crypto_helper.rb:21: warning: constant ::Bignum is deprecated
/home/ngo/dnscat2/server/libs/dnser.rb:379: warning: constant ::Fixnum is deprecated
```