### PR TITLE
Removes "POTENTIAL CACHE HIT" diagnostic

### DIFF
--- a/server/libs/dnser.rb
+++ b/server/libs/dnser.rb
@@ -859,7 +859,7 @@ class DNSer
 
             # Verify it deeper (for security reasons)
             if(!cached.nil?)
-              puts("POTENTIAL CACHE HIT")
+              #puts("POTENTIAL CACHE HIT")
               if(request == cached[:request])
                 puts("CACHE HIT")
                 transaction.reply!(cached[:response])


### PR DESCRIPTION
These messages get printed too frequently and clobber my windows, though I've never actually seen a real cache hit. 