### PR TITLE
Update ll.c

### DIFF
--- a/client/libs/ll.c
+++ b/client/libs/ll.c
@@ -82,7 +82,7 @@ static int compare(ll_t *ll, ll_index_t a, ll_index_t b)
       if(ll->cmpfunc)
         return ll->cmpfunc(a.value.ptr, b.value.ptr);
       else
-        return a.value.ptr == a.value.ptr;
+        return a.value.ptr == b.value.ptr;
   }
 
   printf("We forgot to handle a linked-list type!\n");


### PR DESCRIPTION
Fixes:

```
libs/ll.c: In function 'compare':
libs/ll.c:85:28: warning: self-comparison always evaluates to true [-Wtautological-compare]                                                                                
         return a.value.ptr == a.value.ptr;
```