### PR TITLE
Use latest sha3 gem

### DIFF
--- a/server/Gemfile.lock
+++ b/server/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     ecdsa (1.2.0)
     salsa20 (0.1.1)
-    sha3 (1.0.1)
+    sha3 (1.0.5)
     trollop (2.1.2)
 
 PLATFORMS


### PR DESCRIPTION
so that `bundle install` succeeds in arm architectures.

Tested on a Kali VM on a mac book pro m2