### PR TITLE
feat: add Docker example, fix server, and add Dockerfile for client

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:22.04 as builder
+
+RUN apt-get update && apt-get install -y build-essential
+COPY . /build
+WORKDIR /build
+RUN make
+
+
+FROM ubuntu:22.04 
+COPY --from=builder /build/dnscat /app/dnscat
+WORKDIR /app
+ENV DNSCAT_SERVER=""
+ENV DNSCAT_SECRET=""
+
+RUN echo '#!/bin/sh' > run.sh && \
+    echo '/app/dnscat --dns server=${DNSCAT_SERVER},port=53 --secret=${DNSCAT_SECRET}' >> run.sh && \
+    chmod +x run.sh
+
+
+ENTRYPOINT tail -f /dev/null

--- a/examples/docker/Makefile
+++ b/examples/docker/Makefile
@@ -1,0 +1,11 @@
+up:
+	@docker compose up -d --build 
+
+down:
+	@docker compose down
+
+run-server: up
+	@docker compose exec dnscat-server /app/run.sh
+	
+run-client: up
+	@docker compose exec dnscat-client /app/run.sh

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -1,0 +1,34 @@
+# Docker Example
+In this example, a server and a client are configured through Docker.
+To understand how everything works, see the `Dockerfile`s in server and client.
+
+## Usage
+Run the stack with: 
+```bash
+make up
+``` 
+
+it starts the client and server. Actually, no dnscat services are running. 
+
+Once the stack is executed, run the server with:
+```bash
+make run-server
+```
+
+Now, you have a `dnscat2` DNS server and a shell in the container.
+
+The third step is to run the client: 
+```bash
+make run-client
+```
+
+With this command, the client connects itself to the server.
+
+### Environment variables
+For the server:
+- `DNSCAT_SECRET`: the secret that should be used by the client.
+- `DNS_OPTS`: the `dns` options 
+
+For the client:
+- `DNSCAT_SECRET`: the secret that should be used
+- `DNSCAT_SERVER`: the dnscat2 server IP address.

--- a/examples/docker/compose.yaml
+++ b/examples/docker/compose.yaml
@@ -1,0 +1,33 @@
+services:
+  dnscat-server:
+    platform: linux/amd64
+    build:
+      context: ../../server
+    environment:
+      - DNSCAT_SECRET=dnscat2 
+      - DNS_OPTS=host=0.0.0.0,port=53
+
+    networks:
+      test-network:
+        ipv4_address: 10.254.0.2
+
+
+  dnscat-client:
+    build:
+      context: ../../client
+    environment:
+      - DNSCAT_SECRET=dnscat2 
+      - DNSCAT_SERVER=10.254.0.2
+
+    networks:
+      test-network:
+        ipv4_address: 10.254.0.3
+
+
+networks:
+  test-network:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 10.254.0.0/24
+

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,9 +1,20 @@
-FROM ruby:2.1-onbuild
-MAINTAINER Mark Percival <m@mdp.im>
+FROM ruby:3.0
+
+LABEL MAINTAINER="Mark Percival <m@mdp.im>"
 
 EXPOSE 53/udp
+COPY . /app
+WORKDIR /app
+ENV DNSCAT_SECRET=""
+ENV DNS_OPTS=""
 
-CMD ["ruby ./dnscat2.rb"]
+RUN gem install bundler && bundle install
+RUN echo '#!/bin/sh' > run.sh && \
+    echo 'ruby dnscat2.rb $( [ -n "$DNSCAT_SECRET" ] && echo --secret=$DNSCAT_SECRET ) $( [ -n "$DNS_OPTS" ] && echo --dns $DNS_OPTS )' >> run.sh && \
+    chmod +x run.sh
+
+ENTRYPOINT  tail -f /dev/null
+
 
 # Run it
 #   docker run -p 53:53/udp -it --rm mpercival/dnscat2 ruby ./dnscat2.rb foo.org


### PR DESCRIPTION
This PR: 
* adds and example for using `dnscat2` with Docker (a docker-compose with a client and a server) 
* fixes some errors in the server `Dockerfile`
* adds a `Dockerfile` for the client. 
 
